### PR TITLE
fix: improve parsing of rows that have multiple spaces

### DIFF
--- a/src/asdf.ts
+++ b/src/asdf.ts
@@ -13,7 +13,8 @@ export async function parseToolVersions(
 
   const tools = new Map<string, string>()
   for await (const line of readInterface) {
-    const tool = line.split(' ')
+    const simplifiedLine = line.replace(/ +/g, ' ')
+    const tool = simplifiedLine.split(' ')
     if (tool[0].length !== 0) {
       tools.set(tool[0], tool[1])
     }


### PR DESCRIPTION
Resolves the issue that when your `.tool-versions`-file has multiple spaces between tool name and the version it's not correctly being parsed.

```
node   22.16.0
```

before resulted in:
```
Map(9) {
  'node' => ''
}
```

this change fixes this:
```
Map(9) {
  'node' => '22.16.0'
}
```