### PR TITLE
feat: upgrade action runtime from node20 to node24

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set Node.js 22.x
+      - name: Set Node.js 24.x
         uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
       - run: |
           npm install
       - run: |

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   working_directory:
     required: false   # Defaults to root unless defined by user
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'file-text'


### PR DESCRIPTION
## Summary

- Change `action.yml` runtime from `node20` to `node24`
- Node20 is deprecated in GitHub Actions; this resolves the deprecation warning
- Verified: `npm run all` (build, format, lint, package, all 4 tests) passes on Node 24

Closes #512

## Test plan

- [x] `npm run build` — TypeScript compiles without errors
- [x] `npm run format` — no formatting changes needed
- [x] `npm run lint` — no lint errors
- [x] `npm run package` — ncc bundles successfully
- [x] `npm test` — all 4 tests pass (2 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)